### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server implementation that integrates with [gitingest](https://github.com/cyclotruc/gitingest) for turning any Git repository into a simple text digest of its codebase.
 
+<a href="https://glama.ai/mcp/servers/@narumiruna/gitingest-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@narumiruna/gitingest-mcp/badge" alt="Gitingest Server MCP server" />
+</a>
+
 ## Features
 
 - Easy integration with AI assistants through the Model Context Protocol


### PR DESCRIPTION
This PR adds a badge for the [Gitingest MCP Server](https://glama.ai/mcp/servers/@narumiruna/gitingest-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@narumiruna/gitingest-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@narumiruna/gitingest-mcp/badge" alt="Gitingest Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.