### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ A Model Context Protocol (MCP) server implementation that integrates with [gitin
   <img width="380" height="200" src="https://glama.ai/mcp/servers/@narumiruna/gitingest-mcp/badge" alt="Gitingest Server MCP server" />
 </a>
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/narumiruna-gitingest-mcp).
+
 ## Features
 
 - Easy integration with AI assistants through the Model Context Protocol


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/narumiruna-gitingest-mcp)